### PR TITLE
enable multiple fastd instances with different interface ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ libvirt/cache
 libvirt/webroot
 d201*/
 vagrant-*/
+nohup.out

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .vagrant/
 libvirt/cache
 libvirt/webroot
+d201*/
+vagrant-*/

--- a/README.markdown
+++ b/README.markdown
@@ -127,15 +127,20 @@ You need about 10 GB free diskspace (1.2 GB for each f the 8 virtual machines) i
 
 The following will initialise a git repository in all fastd subdirs and the icvpn directory,
 these are the repositories of the communities. They will be checked out by the created
-machines.
+machines:
 
     for dir in fastd/* icvpn; do ( cd ${dir} ; git init ; git add --all ; git commit -m "Initial commit" ) done
 
-Now we can rollout some of the machines.
+Now we can rollout some of the machines:
 
     vagrant up services gc-gw0 gc-gw1 mp-gw0 mp-gw1
     # Get a cup of coffee, take a walk or do something interesting. This will take time...
     vagrant ssh gc-gw0
+
+Look around the mashines. For example check for running services with:
+
+    service --status-all 2>&1 | egrep '(bird6|openvpn|fastd|alfred|bat)'
+    pgrep -lf '(bird6|openvpn|fastd|alfred|bat)'
     
 In case the ssh login doesn't work: Vagrant creates all VMs with the user "vagrant" and the standard password "vagrant". 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,9 +8,9 @@ set -x
 MACHINE=$1
 
 # optional: if you have brances in your own repo that should be merged ad the repo here:
-FFNORD_TESTING_REPO=
+FFNORD_TESTING_REPO=https://github.com/rubo77/ffnord-puppet-gateway.git
 # and add the branches here (komma separated):
-FFNORD_TESTING_BRANCHES=()
+FFNORD_TESTING_BRANCHES=('multi_fastd')
 
 SCRIPTPATH="/vagrant"
 MACHINE_PATH="$SCRIPTPATH/machines/${MACHINE}/"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -35,7 +35,7 @@ echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ; '>>/etc/apt/apt.
 export DEBIAN_FRONTEND=noninteractive
 
 # comment this out, if you want to keep manuals, documentation and all locales in your machines
-source $SCRIPTPATH/minify_debian.sh
+#source $SCRIPTPATH/minify_debian.sh
 
 apt-get update
 apt-get install --no-install-recommends -y puppet git tcpdump mtr-tiny
@@ -45,7 +45,7 @@ puppet module install puppetlabs-stdlib
 puppet module install puppetlabs-apt --version 1.5.1
 puppet module install puppetlabs-vcsrepo
 
-# Download the puppet package ffnord
+: '####### Download the puppet package ffnord ######'
 cd /etc/puppet/modules
 git clone https://github.com/ffnord/ffnord-puppet-gateway ffnord
 
@@ -72,4 +72,11 @@ build-firewall
 service iptables-persistent save
 
 # comment this out, if you want to keep manuals, documentation and all locales in your machines
-source $SCRIPTPATH/minify_debian.sh
+#source $SCRIPTPATH/minify_debian.sh
+
+service alfred start
+/etc/init.d/fastd restart
+
+: '####### Check for services if they are running correctly ######'
+service --status-all 2>&1 | egrep '(bird6|openvpn|fastd|alfred|bat)'
+pgrep -lf '(bird6|openvpn|fastd|alfred|bat)'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,9 +8,9 @@ set -x
 MACHINE=$1
 
 # optional: if you have brances in your own repo that should be merged ad the repo here:
-FFNORD_TESTING_REPO=https://github.com/rubo77/ffnord-puppet-gateway.git
+FFNORD_TESTING_REPO=
 # and add the branches here (komma separated):
-FFNORD_TESTING_BRANCHES=('multi_fastd')
+FFNORD_TESTING_BRANCHES=('')
 
 SCRIPTPATH="/vagrant"
 MACHINE_PATH="$SCRIPTPATH/machines/${MACHINE}/"

--- a/machines/gc-gw0/manifest.pp
+++ b/machines/gc-gw0/manifest.pp
@@ -25,6 +25,18 @@ ffnord::mesh { 'mesh_ffgc':
   dns_servers => [ '10.35.5.1', '10.35.10.1', '10.35.15.1', '10.35.20.1' ],
 }
 
+ffnord::fastd { "ffgc_1280":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-1280",
+    mesh_mac        => "de:ad:be:ef:fd:00",
+    vpn_mac         => "de:ad:be:ef:fc:00",
+    mesh_mtu        => 1280,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 11280,
+    fastd_peers_git => '/vagrant/fastd/gc/'
+}
+
 ffnord::icvpn::setup { 'gotham_city0':
   icvpn_as           => 65035,
   icvpn_ipv4_address => "10.0.1.1",

--- a/machines/gc-gw0/manifest.pp
+++ b/machines/gc-gw0/manifest.pp
@@ -18,22 +18,22 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10035,
+  fastd_port       => 11235,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.0.2 10.35.4.254' ],
   dns_servers => [ '10.35.5.1', '10.35.10.1', '10.35.15.1', '10.35.20.1' ],
 }
 
-ffnord::fastd { "ffgc_1280":
+ffnord::fastd { "ffgc_old":
     mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
-    mesh_interface  => "ffgc-1280",
+    mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:00",
     vpn_mac         => "de:ad:be:ef:fc:00",
-    mesh_mtu        => 1280,
+    mesh_mtu        => 1460,
     fastd_secret    => "/root/fastd_secret.conf",
-    fastd_port      => 11280,
+    fastd_port      => 10000,
     fastd_peers_git => '/vagrant/fastd/gc/'
 }
 

--- a/machines/gc-gw0/manifest.pp
+++ b/machines/gc-gw0/manifest.pp
@@ -31,9 +31,9 @@ ffnord::fastd { "ffgc_old":
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:00",
     vpn_mac         => "de:ad:be:ef:fc:00",
-    mesh_mtu        => 1460,
+    mesh_mtu        => 1426,
     fastd_secret    => "/root/fastd_secret.conf",
-    fastd_port      => 10000,
+    fastd_port      => 10035,
     fastd_peers_git => '/vagrant/fastd/gc/'
 }
 

--- a/machines/gc-gw0/manifest.pp
+++ b/machines/gc-gw0/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffgc':
 }
 
 ffnord::fastd { "ffgc_old":
-    mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:00",

--- a/machines/gc-gw1/manifest.pp
+++ b/machines/gc-gw1/manifest.pp
@@ -18,11 +18,23 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10035,
+  fastd_port       => 11280,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.5.2 10.35.9.254' ],
   dns_servers => [ '10.35.0.1', '10.35.10.1', '10.35.15.1', '10.35.20.1' ],
+}
+
+ffnord::fastd { "ffgc_old":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-old",
+    mesh_mac        => "de:ad:be:ef:fd:01",
+    vpn_mac         => "de:ad:be:ef:fc:01",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10035,
+    fastd_peers_git => '/vagrant/fastd/gc/'
 }
 
 ffnord::icvpn::setup { 'gotham_city1':

--- a/machines/gc-gw1/manifest.pp
+++ b/machines/gc-gw1/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffgc':
 }
 
 ffnord::fastd { "ffgc_old":
-    mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:01",

--- a/machines/gc-gw1/manifest.pp
+++ b/machines/gc-gw1/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 11280,
+  fastd_port       => 11235,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.5.2 10.35.9.254' ],

--- a/machines/gc-gw2/manifest.pp
+++ b/machines/gc-gw2/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10035,
+  fastd_port       => 11235,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.10.2 10.35.14.254' ],

--- a/machines/gc-gw2/manifest.pp
+++ b/machines/gc-gw2/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffgc':
 }
 
 ffnord::fastd { "ffgc_old":
-    mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:02",

--- a/machines/gc-gw2/manifest.pp
+++ b/machines/gc-gw2/manifest.pp
@@ -25,6 +25,18 @@ ffnord::mesh { 'mesh_ffgc':
   dns_servers => [ '10.35.0.1', '10.35.5.1', '10.35.15.1', '10.35.20.1' ],
 }
 
+ffnord::fastd { "ffgc_old":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-old",
+    mesh_mac        => "de:ad:be:ef:fd:02",
+    vpn_mac         => "de:ad:be:ef:fc:02",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10035,
+    fastd_peers_git => '/vagrant/fastd/gc/'
+}
+
 ffnord::icvpn::setup { 'gotham_city2':
   icvpn_as           => 65035,
   icvpn_ipv4_address => "10.112.0.1",

--- a/machines/gc-gw3/manifest.pp
+++ b/machines/gc-gw3/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffgc':
 }
 
 ffnord::fastd { "ffgc_old":
-    mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:03",

--- a/machines/gc-gw3/manifest.pp
+++ b/machines/gc-gw3/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10035,
+  fastd_port       => 11235,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.15.2 10.35.19.254' ],

--- a/machines/gc-gw3/manifest.pp
+++ b/machines/gc-gw3/manifest.pp
@@ -25,6 +25,18 @@ ffnord::mesh { 'mesh_ffgc':
   dns_servers => [ '10.35.0.1', '10.35.5.1', '10.35.10.1', '10.35.20.1' ],
 }
 
+ffnord::fastd { "ffgc_old":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-old",
+    mesh_mac        => "de:ad:be:ef:fd:03",
+    vpn_mac         => "de:ad:be:ef:fc:03",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10035,
+    fastd_peers_git => '/vagrant/fastd/gc/'
+}
+
 ffnord::icvpn::setup { 'gotham_city2':
   icvpn_as           => 65035,
   icvpn_ipv4_address => "10.112.0.1",

--- a/machines/gc-gw4/manifest.pp
+++ b/machines/gc-gw4/manifest.pp
@@ -25,6 +25,18 @@ ffnord::mesh { 'mesh_ffgc':
   dns_servers => [ '10.35.0.1', '10.35.5.1', '10.35.10.1', '10.35.15.1' ],
 }
 
+ffnord::fastd { "ffgc_old":
+    mesh_name       => "mesh_ffgc",
+    mesh_code       => "ffgc",
+    mesh_interface  => "ffgc-old",
+    mesh_mac        => "de:ad:be:ef:fd:04",
+    vpn_mac         => "de:ad:be:ef:fc:04",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10035,
+    fastd_peers_git => '/vagrant/fastd/gc/'
+}
+
 ffnord::icvpn::setup { 'gotham_city2':
   icvpn_as           => 65035,
   icvpn_ipv4_address => "10.112.0.1",

--- a/machines/gc-gw4/manifest.pp
+++ b/machines/gc-gw4/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffgc':
 }
 
 ffnord::fastd { "ffgc_old":
-    mesh_name       => "mesh_ffgc",
     mesh_code       => "ffgc",
     mesh_interface  => "ffgc-old",
     mesh_mac        => "de:ad:be:ef:fd:04",

--- a/machines/gc-gw4/manifest.pp
+++ b/machines/gc-gw4/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffgc':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10035,
+  fastd_port       => 11235,
   fastd_peers_git  => '/vagrant/fastd/gc/',
 
   dhcp_ranges => [ '10.35.20.2 10.35.24.254' ],

--- a/machines/mp-gw0/manifest.pp
+++ b/machines/mp-gw0/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffmp':
 }
 
 ffnord::fastd { "ffmp_old":
-    mesh_name       => "mesh_ffmp",
     mesh_code       => "ffmp",
     mesh_interface  => "ffmp-old",
     mesh_mac        => "de:ad:be:ef:fd:00",

--- a/machines/mp-gw0/manifest.pp
+++ b/machines/mp-gw0/manifest.pp
@@ -11,6 +11,7 @@ ffnord::mesh { 'mesh_ffmp':
   mesh_as          => 65003,
   mesh_code        => "ffmp",
   mesh_mac         => "de:ad:be:ef:ff:00",
+  vpn_mac          => "de:ad:be:ef:fe:00",
   mesh_ipv6        => "fdd7:e0f1:4128::ff00/64",
   mesh_ipv4        => "10.215.0.1/17",
   range_ipv4       => "10.215.0.0/16",
@@ -22,6 +23,18 @@ ffnord::mesh { 'mesh_ffmp':
 
   dhcp_ranges => [ '10.215.0.2 10.215.7.254' ],
   dns_servers => [ '10.215.8.1' ],
+}
+
+ffnord::fastd { "ffmp_old":
+    mesh_name       => "mesh_ffmp",
+    mesh_code       => "ffmp",
+    mesh_interface  => "ffmp-old",
+    mesh_mac        => "de:ad:be:ef:fd:00",
+    vpn_mac         => "de:ad:be:ef:fc:00",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10003,
+    fastd_peers_git => '/vagrant/fastd/mp/'
 }
 
 ffnord::icvpn::setup { 'gotham_city0':

--- a/machines/mp-gw0/manifest.pp
+++ b/machines/mp-gw0/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffmp':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10003,
+  fastd_port       => 11203,
   fastd_peers_git  => '/vagrant/fastd/mp/',
 
   dhcp_ranges => [ '10.215.0.2 10.215.7.254' ],

--- a/machines/mp-gw1/manifest.pp
+++ b/machines/mp-gw1/manifest.pp
@@ -26,7 +26,6 @@ ffnord::mesh { 'mesh_ffmp':
 }
 
 ffnord::fastd { "ffmp_old":
-    mesh_name       => "mesh_ffmp",
     mesh_code       => "ffmp",
     mesh_interface  => "ffmp-old",
     mesh_mac        => "de:ad:be:ef:fd:01",

--- a/machines/mp-gw1/manifest.pp
+++ b/machines/mp-gw1/manifest.pp
@@ -11,6 +11,7 @@ ffnord::mesh { 'mesh_ffmp':
   mesh_as          => 65003,
   mesh_code        => "ffmp",
   mesh_mac         => "de:ad:be:ef:ff:01",
+  vpn_mac          => "de:ad:be:ef:fe:01",
   mesh_ipv6        => "fdd7:e0f1:4128::ff01/64",
   mesh_ipv4        => "10.215.8.1/17",
   range_ipv4       => "10.215.0.0/16",
@@ -22,6 +23,18 @@ ffnord::mesh { 'mesh_ffmp':
 
   dhcp_ranges => [ '10.215.8.2 10.215.15.254' ],
   dns_servers => [ '10.215.0.1' ],
+}
+
+ffnord::fastd { "ffmp_old":
+    mesh_name       => "mesh_ffmp",
+    mesh_code       => "ffmp",
+    mesh_interface  => "ffmp-old",
+    mesh_mac        => "de:ad:be:ef:fd:01",
+    vpn_mac         => "de:ad:be:ef:fc:01",
+    mesh_mtu        => 1426,
+    fastd_secret    => "/root/fastd_secret.conf",
+    fastd_port      => 10003,
+    fastd_peers_git => '/vagrant/fastd/mp/'
 }
 
 ffnord::icvpn::setup { 'gotham_city0':

--- a/machines/mp-gw1/manifest.pp
+++ b/machines/mp-gw1/manifest.pp
@@ -18,7 +18,7 @@ ffnord::mesh { 'mesh_ffmp':
   mesh_peerings    => "/root/mesh_peerings.yaml",
 
   fastd_secret     => "/root/fastd_secret.conf",
-  fastd_port       => 10003,
+  fastd_port       => 11203,
   fastd_peers_git  => '/vagrant/fastd/mp/',
 
   dhcp_ranges => [ '10.215.8.2 10.215.15.254' ],


### PR DESCRIPTION
Accordingly to https://github.com/ffnord/ffnord-puppet-gateway/pull/120